### PR TITLE
Truncate long filenames

### DIFF
--- a/src/resources/js/components/enso/filemanager/File.vue
+++ b/src/resources/js/components/enso/filemanager/File.vue
@@ -9,7 +9,7 @@
                 size="3x"/>
         </p>
         <h5 class="title is-5 has-text-centered" v-tooltip="file.name">
-            {{ file.name|truncate }}
+            {{ file.name | truncate }}
         </h5>
         <p class="has-text-centered"
            v-tooltip="file.createdAt">
@@ -93,15 +93,12 @@ export default {
     directives: { tooltip: VTooltip },
 
     components: { Popover, Modal },
+    
     filters: {
-        truncate: function(value) {
-            if (value.length > 30) {
-                value = value.substring(0, 16) + '...' + value.slice(-10);
-            }
-
-
-            return value
-
+        truncate(value) {
+            return value.length > 30
+                ? `${value.substring(0, 16)}...${value.slice(-10)}`
+                : value;
         }
     },
 

--- a/src/resources/js/components/enso/filemanager/File.vue
+++ b/src/resources/js/components/enso/filemanager/File.vue
@@ -8,10 +8,11 @@
             <fa :icon="icon"
                 size="3x"/>
         </p>
-        <h5 class="title is-5 has-text-centered">
-            {{ file.name }}
+        <h5 class="title is-5 has-text-centered" v-tooltip="file.name">
+            {{ file.name|truncate }}
         </h5>
-        <p class="has-text-centered">
+        <p class="has-text-centered"
+           v-tooltip="file.createdAt">
             <span class="icon is-small">
                 <fa icon="calendar-alt"/>
             </span>
@@ -73,6 +74,7 @@ import {
 import Popover from '../bulma/Popover.vue';
 import formatDistance from '../../../modules/enso/plugins/date-fns/formatDistance';
 import Modal from './Modal.vue';
+import { VTooltip } from "v-tooltip";
 
 library.add(
     faFile, faEye, faCloudDownloadAlt, faTrashAlt, faLink, faCalendarAlt,
@@ -88,7 +90,20 @@ const Pdfs = ['pdf'];
 export default {
     name: 'File',
 
+    directives: { tooltip: VTooltip },
+
     components: { Popover, Modal },
+    filters: {
+        truncate: function(value) {
+            if (value.length > 30) {
+                value = value.substring(0, 16) + '...' + value.slice(-10);
+            }
+
+
+            return value
+
+        }
+    },
 
     props: {
         file: {


### PR DESCRIPTION
truncate display of long filenames (prevents 3+lines of filename messing up the layout)
shows the full name in a tooltip