### PR TITLE
Support model-based file permissions

### DIFF
--- a/src/app/Policies/FilePolicy.php
+++ b/src/app/Policies/FilePolicy.php
@@ -19,11 +19,14 @@ class FilePolicy
 
     public function handle(User $user, File $file)
     {
-        $attachedTo = ($file->attachable->documentable ?? $file->attachable);
-        if (method_exists($attachedTo, 'canAccess') && is_callable([$attachedTo, 'canAccess'])) {
+        $attachedTo = $file->attachable->documentable
+            ?? $file->attachable;
+
+        if (method_exists($attachedTo, 'canAccess')
+            && is_callable([$attachedTo, 'canAccess'])) {
             return $attachedTo->canAccess($user, $file);
         }
-
+        
         return $user->id === intval($file->created_by);
     }
 }

--- a/src/app/Policies/FilePolicy.php
+++ b/src/app/Policies/FilePolicy.php
@@ -23,7 +23,7 @@ class FilePolicy
         if (method_exists($attachedTo, 'canAccess') && is_callable([$attachedTo, 'canAccess'])) {
             return $attachedTo->canAccess($user, $file);
         }
-        
+
         return $user->id === intval($file->created_by);
     }
 }

--- a/src/app/Policies/FilePolicy.php
+++ b/src/app/Policies/FilePolicy.php
@@ -19,11 +19,11 @@ class FilePolicy
 
     public function handle(User $user, File $file)
     {
-        $attachedTo = ($file->attachable->documentable ?: $file->attachable);
+        $attachedTo = ($file->attachable->documentable ?? $file->attachable);
         if (method_exists($attachedTo, 'canAccess') && is_callable([$attachedTo, 'canAccess'])) {
             return $attachedTo->canAccess($user, $file);
-        } else {
-            return $user->id === intval($file->created_by);
         }
+        
+        return $user->id === intval($file->created_by);
     }
 }

--- a/src/app/Policies/FilePolicy.php
+++ b/src/app/Policies/FilePolicy.php
@@ -20,9 +20,10 @@ class FilePolicy
     public function handle(User $user, File $file)
     {
         $attachedTo = ($file->attachable->documentable ?: $file->attachable);
-        if(method_exists($attachedTo, 'canAccess') && is_callable([$attachedTo, 'canAccess']))
+        if (method_exists($attachedTo, 'canAccess') && is_callable([$attachedTo, 'canAccess'])) {
             return $attachedTo->canAccess($user, $file);
-        else
+        } else {
             return $user->id === intval($file->created_by);
+        }
     }
 }

--- a/src/app/Policies/FilePolicy.php
+++ b/src/app/Policies/FilePolicy.php
@@ -19,6 +19,10 @@ class FilePolicy
 
     public function handle(User $user, File $file)
     {
-        return $user->id === intval($file->created_by);
+        $attachedTo = ($file->attachable->documentable ?: $file->attachable);
+        if(method_exists($attachedTo, 'canAccess') && is_callable([$attachedTo, 'canAccess']))
+            return $attachedTo->canAccess($user, $file);
+        else
+            return $user->id === intval($file->created_by);
     }
 }

--- a/src/app/Policies/FilePolicy.php
+++ b/src/app/Policies/FilePolicy.php
@@ -26,7 +26,7 @@ class FilePolicy
             && is_callable([$attachedTo, 'canAccess'])) {
             return $attachedTo->canAccess($user, $file);
         }
-        
+
         return $user->id === intval($file->created_by);
     }
 }


### PR DESCRIPTION
Delegates policy-handling to a `canAccess` method on the related model.
Aware of Enso's Documentable.
Fixes https://github.com/laravel-enso/DocumentsManager/issues/11